### PR TITLE
fix: Pass llm_engine_name to Executor

### DIFF
--- a/agentflow/agentflow/solver.py
+++ b/agentflow/agentflow/solver.py
@@ -230,8 +230,7 @@ def construct_solver(llm_engine_name : str = "gpt-4o",
 
     # Instantiate Executor with tool instances cache
     executor = Executor(
-        # llm_engine_name=llm_engine_name,
-        llm_engine_name="dashscope",
+        llm_engine_name=llm_engine_name,
         root_cache_dir=root_cache_dir,
         verbose=verbose,
         # base_url=base_url,

--- a/quick_start.py
+++ b/quick_start.py
@@ -1,8 +1,11 @@
 # Import the solver
 from agentflow.agentflow.solver import construct_solver
 
-# Set the LLM engine name
-llm_engine_name = "dashscope" # you can use "gpt-4o" as well
+# Set the LLM engine name.
+# Supported engines are "dashscope" and "gpt-4o".
+# By default, it uses "dashscope".
+# To use "gpt-4o", uncomment the line below and comment out the "dashscope" line.
+llm_engine_name = "dashscope"
 # llm_engine_name = "gpt-4o"
 
 # Construct the solver


### PR DESCRIPTION
In the AgentFlow project, the Executor module currently has its LLM engine name hardcoded to dashscope. This prevents users from switching to other supported LLM providers (e.g., gpt-4o), even when a different llm_engine_name is specified during Solver construction.

In agentflow/agentflow/solver.py, the construct_solver function correctly receives the llm_engine_name parameter and passes it to the Initializer and Planner. However, when creating the Executor, the engine name is explicitly set to "dashscope", overriding the user’s provided value. This results in inconsistent behavior, where the system appears configurable but the Executor always uses Dashscope.

Steps to Reproduce

Open quick_start.py.

Change llm_engine_name to gpt-4o (or any engine other than "dashscope").

Run python quick_start.py.

Observe that the Executor still attempts to use Dashscope.

Expected Behavior

The Executor should use the llm_engine_name passed to construct_solver, ensuring all components consistently use the same LLM engine.

Actual Behavior

The Executor ignores the provided value and always uses "dashscope".

Proposed Fix

In agentflow/agentflow/solver.py, update the Executor instantiation to use the function’s llm_engine_name parameter instead of the hardcoded string.

Update comments in quick_start.py to clarify available LLM engine options and how to configure them.