### PR TITLE
Fix: Reset memory for new problem

### DIFF
--- a/agentflow/agentflow/models/memory.py
+++ b/agentflow/agentflow/models/memory.py
@@ -9,6 +9,11 @@ class Memory:
         self.actions: Dict[str, Dict[str, Any]] = {}
         self._init_file_types()
 
+    def reset(self):
+        self.query = None
+        self.files = []
+        self.actions = {}
+
     def set_query(self, query: str) -> None:
         if not isinstance(query, str):
             raise TypeError("Query must be a string")

--- a/agentflow/agentflow/solver.py
+++ b/agentflow/agentflow/solver.py
@@ -48,6 +48,9 @@ class Solver:
         # Update cache directory for the executor
         self.executor.set_query_cache_dir(self.root_cache_dir)
 
+        # Reset memory for new problem
+        self.memory.reset()
+
         # Initialize json_data with basic problem information
         json_data = {
             "query": question,


### PR DESCRIPTION
**Problem**

In the current rollout pipeline, each worker process instantiates a single AgentFlowRollout and reuses the same Solver instance across many tasks. Since Solver holds a persistent Memory object, its internal state (especially actions and tool results) can persist across consecutive calls to Solver.solve() within the same worker.

This causes cross-task contamination: action steps and tool outputs from a previous sample may be mistakenly treated as context for the next sample, leading to unstable planning/verification behavior and incorrect final outputs.

**Fix**

This PR introduces an explicit reset API in Memory and ensures it is invoked at the start of each solve.

Add Memory.reset() to clear per-task state:

def reset(self):
    self.query = None
    self.files = []
    self.actions = {}


Call self.memory.reset() at the beginning of Solver.solve() so every new task starts with a clean memory state:

# Reset memory for new problem
self.memory.reset()


This enforces per-task isolation of memory while keeping the existing design (reusing Solver and other components within each worker process).