### PR TITLE
[fix] python coder tool signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,4 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+deployment/


### PR DESCRIPTION
### ⚡️ Fix: Thread-Safe Python Execution

**Description:**
Replaced `signal.alarm` with `threading` to handle code execution timeouts. 

**Changes:**
- **Executor**: Wraps `exec()` in a daemon thread. Uses `thread.join(timeout)` to enforce limits.
- **Tool**: Updates timeout context manager to use `threading.Timer` (cross-platform compatible).

**Benefits:**
- Fixes `signal only works in main thread` error in multi-threaded training loops.
- Prevents tool execution from blocking or crashing the main application loop.